### PR TITLE
aml-flash-tool: INSTALL: Add Ubuntu 19.04 support

### DIFF
--- a/aml-flash-tool/INSTALL
+++ b/aml-flash-tool/INSTALL
@@ -38,7 +38,7 @@ if [[ "$DISTRIB_RELEASE" =~ "12" ]]; then
 	RULE="$RULES_DIR/70-persistent-usb-ubuntu12.rules"
 	sudo cp $RULE /etc/udev/rules.d
 	sudo sed -i s/OWNER=\"amlogic\"/OWNER=\"`whoami`\"/g /etc/udev/rules.d/$(basename $RULE)
-elif [[ "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" ]]; then
+elif [[ "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "19" ]]; then
 	RULE="$RULES_DIR/70-persistent-usb-ubuntu14.rules"
 	sudo cp $RULE /etc/udev/rules.d
 else


### PR DESCRIPTION
I have tested on my Ubuntu 19.04,
Fixed "Ubuntu 19.04 haven't been verified" error for installtion aml-flash-tool on Ubuntu 19.04 Release.
