### PR TITLE
Update installation scripts for Ubuntu 24 support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,14 +24,14 @@ error_msg() {
 }
 
 setup_ubuntu_host() {
-	local hostdeps="libusb-dev git parted lib32z1 lib32stdc++6 libusb-0.1-4 libusb-1.0-0-dev libusb-1.0-0 ccache libncurses5 pv base-files linux-base xz-utils"
+	local hostdeps="libusb-dev git parted lib32z1 lib32stdc++6 libusb-0.1-4 libusb-1.0-0-dev libusb-1.0-0 ccache pv base-files linux-base xz-utils"
 	local deps=()
 	local installed=$(dpkg-query -W -f '${db:Status-Abbrev}|${binary:Package}\n' '*' 2>/dev/null | grep '^ii' | awk -F '|' '{print $2}' | cut -d ':' -f 1)
 
-	if [[ "$DISTRIB" == "Ubuntu" ]] && [[ "$DISTRIB_RELEASE" == "18.10" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" ]]; then
-		hostdeps="$hostdeps lib32ncurses6"
+	if [[ "$DISTRIB" == "Ubuntu" ]] && [[ "$DISTRIB_RELEASE" == "18.10" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
+		hostdeps="$hostdeps lib32ncurses6 libncurses6"
 	else
-		hostdeps="$hostdeps lib32ncurses5"
+		hostdeps="$hostdeps lib32ncurses5 libncurses5"
 	fi
 
 	for packet in $hostdeps; do
@@ -68,10 +68,10 @@ setup_arch_host() {
 
 prepare_host() {
 	case $DISTRIB in
-	    "\"Arch\"")
+	    \"Arch\"|Arch)
 	    setup_arch_host
 		;;
-	    "\"Ubuntu\"")
+	    \"Ubuntu\"|Ubuntu)
 	    setup_ubuntu_host
 		;;
 		*)

--- a/aml-flash-tool/INSTALL
+++ b/aml-flash-tool/INSTALL
@@ -49,7 +49,7 @@ if [[ "$DISTRIB_RELEASE" =~ "12" ]]; then
 	RULE="$RULES_DIR/70-persistent-usb-ubuntu12.rules"
 	sudo cp $RULE /etc/udev/rules.d
 	sudo sed -i s/OWNER=\"amlogic\"/OWNER=\"`whoami`\"/g /etc/udev/rules.d/$(basename $RULE)
-elif [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "19" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" ]]; then
+elif [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "19" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="$RULES_DIR/70-persistent-usb-ubuntu14.rules"
 	sudo cp $RULE /etc/udev/rules.d
 else

--- a/aml-flash-tool/UNINSTALL
+++ b/aml-flash-tool/UNINSTALL
@@ -34,7 +34,7 @@ echo "Removing USB rules..."
 
 if [[ "$DISTRIB_RELEASE" =~ "12" ]]; then
 	RULE="/etc/udev/rules.d/70-persistent-usb-ubuntu12.rules"
-elif [[ "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" ]]; then
+elif [[ "$DISTRIB_RELEASE" =~ "14" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="/etc/udev/rules.d/70-persistent-usb-ubuntu14.rules"
 else
 #	error_msg "Ubuntu $DISTRIB_RELEASE haven't been verified!"

--- a/rk-flash-tool/INSTALL
+++ b/rk-flash-tool/INSTALL
@@ -46,7 +46,7 @@ fi
 
 echo "Installing USB rules..."
 
-if [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" ]]; then
+if [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="$RULES_DIR/80-rockchip-usb.rules"
 	sudo cp $RULE /etc/udev/rules.d
 else

--- a/rk-flash-tool/UNINSTALL
+++ b/rk-flash-tool/UNINSTALL
@@ -33,7 +33,7 @@ echo ""
 
 echo "Removing USB rules..."
 
-if [[ "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" ]]; then
+if [[ "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="/etc/udev/rules.d/80-rockchip-usb.rules"
 else
 #	error_msg "Ubuntu $DISTRIB_RELEASE haven't been verified!"

--- a/tone-dfu-tool/INSTALL
+++ b/tone-dfu-tool/INSTALL
@@ -44,7 +44,7 @@ fi
 
 echo "Installing USB rules..."
 
-if [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" ]]; then
+if [[ "$IGNORE_CHECK" == "yes" || "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="$RULES_DIR/80-tone-usb.rules"
 	sudo cp $RULE /etc/udev/rules.d
 else

--- a/tone-dfu-tool/UNINSTALL
+++ b/tone-dfu-tool/UNINSTALL
@@ -32,7 +32,7 @@ echo ""
 
 echo "Removing USB rules..."
 
-if [[ "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" ]]; then
+if [[ "$DISTRIB_RELEASE" =~ "16" || "$DISTRIB_RELEASE" =~ "18" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "22" || "$DISTRIB_RELEASE" =~ "24" ]]; then
 	RULE="/etc/udev/rules.d/80-tone-usb.rules"
 else
 #	error_msg "Ubuntu $DISTRIB_RELEASE haven't been verified!"


### PR DESCRIPTION
Installation scripts now accommodate Ubuntu 24 and updated dependency versions to ensure compatibility.
