### PR TITLE
fix: correct Ubuntu/macOS host_os detection via uname -s

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/aml-flash-tool/INSTALL
+++ b/aml-flash-tool/INSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/aml-flash-tool/UNINSTALL
+++ b/aml-flash-tool/UNINSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/aml-flash-tool/aml-burn-tool
+++ b/aml-flash-tool/aml-burn-tool
@@ -6,7 +6,7 @@ BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 FLASH_TOOL="$BASE/flash-tool"
 KHADAS_TOOL="/usr/local/bin/$(basename $0)"
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	ADNL_TOOL="$BASE/tools/adnl/macos/adnl_burn_pkg"
 else
 	ADNL_TOOL="$BASE/tools/adnl/adnl_burn_pkg"
@@ -93,7 +93,7 @@ if [ -z "$BOARD" ]; then
 	BOARD="VIM1"
 fi
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	if fdisk -t "$IMAGE" && ! fdisk -d "$IMAGE" | grep -q 0xEE; then
 		IMAGE_INSTALL_TYPE="SD-USB"
 	else
@@ -129,7 +129,7 @@ else
 		exit -1
 	fi
 
-	if [ "$(uname -o)" = "Darwin" ]; then
+	if [ "$(uname -s)" = "Darwin" ]; then
 		if ! ioreg -p IOUSB -l | grep -q "Amlogic" > /dev/null; then
 			error_msg "You should put your board enter upgrade mode!"
 			exit -1

--- a/aml-flash-tool/flash-tool
+++ b/aml-flash-tool/flash-tool
@@ -201,7 +201,7 @@ done
 
 # Testing host machine
 # --------------------
-host_os=`uname -o`
+host_os=`uname -s`
 host_machine=`uname -m|grep -i "x86"`
 if [ ! -z "$host_os" ]; then
    if [ "$host_os" = "Darwin" ]; then

--- a/rk-flash-tool/INSTALL
+++ b/rk-flash-tool/INSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	ANDROID_TOOL_CONFIG="$BASE/tools/macos_upgrade_tool/config.ini"
 	DISTRIB=macOS
 else

--- a/rk-flash-tool/UNINSTALL
+++ b/rk-flash-tool/UNINSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/rk-flash-tool/rk-burn-tool
+++ b/rk-flash-tool/rk-burn-tool
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	ANDROID_TOOL="$BASE/tools/macos_upgrade_tool/upgrade_tool"
 else
 	ANDROID_TOOL="$BASE/tools/Linux_Upgrade_Tool/upgrade_tool"
@@ -79,7 +79,7 @@ case $IMAGE in
 	;;
 esac
 
-if [ "$(uname -o)" = "Darwin" ] ; then
+if [ "$(uname -s)" = "Darwin" ] ; then
 	if fdisk -t "$IMAGE" && ! fdisk -d "$IMAGE" | grep -q 0xEE; then
 		IMAGE_INSTALL_TYPE="SD-USB"
 	else
@@ -115,7 +115,7 @@ else
 		exit -1
 	fi
 
-	if [ "$(uname -o)" = "Darwin" ] ; then
+	if [ "$(uname -s)" = "Darwin" ] ; then
 		if ! ioreg -p IOUSB -l -x | grep idVendor | grep -q 2207 || ! ioreg -p IOUSB -l -x | grep idProduct | grep -q "330c\|350b"; then
 			error_msg "You should put your board enter upgrade mode!"
 			exit -1
@@ -129,7 +129,7 @@ else
 
 	echo "Burn to eMMC..."
 
-	if [ "$(uname -o)" = "Darwin" ] && fdisk -t "$IMAGE" && fdisk -d "$IMAGE" | grep -q 0xEE ; then
+	if [ "$(uname -s)" = "Darwin" ] && fdisk -t "$IMAGE" && fdisk -d "$IMAGE" | grep -q 0xEE ; then
 		error_msg "Flashing raw gpt image is currently not supported on mac OS. Please try flashing via oowow instead."
 		exit -1
 	elif parted -s "$IMAGE" p 2> /dev/null | grep -q rootfs 2> /dev/null; then

--- a/tone-dfu-tool/INSTALL
+++ b/tone-dfu-tool/INSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ] ; then
+if [ "$(uname -s)" = "Darwin" ] ; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/tone-dfu-tool/UNINSTALL
+++ b/tone-dfu-tool/UNINSTALL
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ] ; then
+if [ "$(uname -s)" = "Darwin" ] ; then
 	DISTRIB=macOS
 else
 	DISTRIB=$(cat /etc/lsb-release | grep "DISTRIB_ID" | awk -F "=" '{print $2}')

--- a/tone-dfu-tool/tone-burn-tool
+++ b/tone-dfu-tool/tone-burn-tool
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 BASE=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-if [ "$(uname -o)" = "Darwin" ] ; then
+if [ "$(uname -s)" = "Darwin" ] ; then
 	BURN_TOOL="$BASE/tools/macos/tone_dfu_tool"
 else
 	BURN_TOOL="$BASE/tools/`uname -i`/tone_dfu_tool"
@@ -52,7 +52,7 @@ if [ ! -f "$IMAGE" ]; then
 	exit 1
 fi
 
-if [ "$(uname -o)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	if ! ioreg -p IOUSB -l -x | grep idVendor | grep -q "${KHADAS_USB_VID}\|${KHADAS_USB_XMOS_VID}"; then
 		error_msg "You should connect the Tone to your computer!"
 		exit -1


### PR DESCRIPTION
## Problem

On older macOS versions (e.g., macOS 11), `uname -o` is unsupported (BSD uname lacks this GNU option). This causes host OS detection to fail.

Additionally, the flash script inconsistently uses `uname -o` on Ubuntu, even though `uname -s` is the more reliable method across platforms.

Relative issue: 
- https://github.com/khadas/utils/pull/30

<img width="691" alt="图片" src="https://github.com/user-attachments/assets/3fcffa75-a255-4ccd-9e54-1ad13a2315ae" />

## Solution

- ​​macOS​​: Fall back to `uname -s` (outputs Darwin) when -o is unavailable.
- Ubuntu​​: Standardize on `uname -s` (outputs Linux) instead of `uname -o` (GNU/Linux) for consistency. 

<img width="777" alt="图片" src="https://github.com/user-attachments/assets/1f1554a8-0242-4db9-90b8-e536e20d05ee" />
