### PR TITLE
Add an option to aml-burn-tool for keeping existing data

### DIFF
--- a/aml-flash-tool/aml-burn-tool
+++ b/aml-flash-tool/aml-burn-tool
@@ -26,8 +26,10 @@ error_msg() {
 
 usage() {
 	echo -e "Usage:"
-	echo -e "emmc:   $0 -b <VIM1|VIM2|VIM3|VIM4> -i <path-to-image>"
+	echo -e "emmc:   $0 -b <VIM1|VIM2|VIM3|VIM4> -i <path-to-image> [-n]"
 	echo -e "sdcard: $0 -d </dev/sdX> -i <path-to-image>"
+	echo -e "\nOptions:"
+	echo -e "  -n    Do not destroy all partitions (only works with VIM1, VIM2, VIM3)"
 }
 
 flash_sdcard() {
@@ -51,7 +53,10 @@ if [ ! -L $KHADAS_TOOL ]; then
 	exit 1
 fi
 
-while getopts "d:i:b:Dhr" flag; do
+# Default to wipe if the option is not explicitly disabled
+WIPE_OPTION="--wipe"
+
+while getopts "d:i:b:Dhrn" flag; do
 	case $flag in
 		d)
 		DEVICE="$OPTARG"
@@ -67,6 +72,9 @@ while getopts "d:i:b:Dhr" flag; do
 		;;
 		r)
 		RESET_BOARD="yes"
+		;;
+		n)
+		WIPE_OPTION=""
 		;;
 		h)
 		usage
@@ -165,7 +173,7 @@ else
 		else
 			RESET_BOARD=
 		fi
-		$FLASH_TOOL --img=$IMAGE --parts=all --wipe --soc=$SOC ${RESET_BOARD} ${DEBUG}
+		$FLASH_TOOL --img=$IMAGE --parts=all $WIPE_OPTION --soc=$SOC ${RESET_BOARD} ${DEBUG}
 	elif [ "$BOARD" == "VIM4" ] || [ "$BOARD" == "VIM1S" ]; then
 		if [ "$RESET_BOARD" == "yes" ]; then
 			RESET_BOARD="-r 1"

--- a/aml-flash-tool/aml-burn-tool
+++ b/aml-flash-tool/aml-burn-tool
@@ -79,6 +79,7 @@ while getopts "d:i:b:Dhrns" flag; do
 		;;
 		n)
 		ERASE_ALL="no"
+		;;
 		s)
 		SKIP_USB_CHECK="yes"
 		;;

--- a/aml-flash-tool/aml-burn-tool
+++ b/aml-flash-tool/aml-burn-tool
@@ -29,7 +29,7 @@ usage() {
 	echo -e "emmc:   $0 -b <VIM1|VIM2|VIM3|VIM4> -i <path-to-image> [-n]"
 	echo -e "sdcard: $0 -d </dev/sdX> -i <path-to-image>"
 	echo -e "\nOptions:"
-	echo -e "  -n    Do not destroy all partitions (only works with VIM1, VIM2, VIM3)"
+	echo -e "  -n    Do not erase the whole flash chip (default to erase)."
 }
 
 flash_sdcard() {
@@ -53,8 +53,9 @@ if [ ! -L $KHADAS_TOOL ]; then
 	exit 1
 fi
 
-# Default to wipe if the option is not explicitly disabled
-WIPE_OPTION="--wipe"
+# Default to erase if the option is not explicitly provided
+# to match the default behavior of $FLASH_TOOL and $ADNL_TOOL
+ERASE_ALL="yes"
 
 while getopts "d:i:b:Dhrn" flag; do
 	case $flag in
@@ -74,7 +75,7 @@ while getopts "d:i:b:Dhrn" flag; do
 		RESET_BOARD="yes"
 		;;
 		n)
-		WIPE_OPTION=""
+		ERASE_ALL="no"
 		;;
 		h)
 		usage
@@ -173,14 +174,25 @@ else
 		else
 			RESET_BOARD=
 		fi
-		$FLASH_TOOL --img=$IMAGE --parts=all $WIPE_OPTION --soc=$SOC ${RESET_BOARD} ${DEBUG}
+		if [ "$ERASE_ALL" == "yes" ]; then
+			WIPE_OPTION="--wipe"
+		else
+			WIPE_OPTION=
+		fi
+
+		$FLASH_TOOL --img=$IMAGE --parts=all ${WIPE_OPTION} --soc=$SOC ${RESET_BOARD} ${DEBUG}
 	elif [ "$BOARD" == "VIM4" ] || [ "$BOARD" == "VIM1S" ]; then
 		if [ "$RESET_BOARD" == "yes" ]; then
 			RESET_BOARD="-r 1"
 		else
 			RESET_BOARD=
 		fi
-		$ADNL_TOOL -p $IMAGE ${RESET_BOARD}
+		if [ "$ERASE_ALL" == "yes" ]; then
+			ERASE_FLASH="-e 1"
+		else
+			ERASE_FLASH="-e 0"
+		fi
+		$ADNL_TOOL -p $IMAGE ${RESET_BOARD} ${ERASE_FLASH}
 	fi
 fi
 


### PR DESCRIPTION
I've tested the `$FLASH_TOOL` both with and without `--wipe` on an Amlogic S905X3, but I haven't tested `$ADNL_TOOL` with `-e`.